### PR TITLE
Use version 0.6 of node-red-contrib-viseo-botbuilder

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "node-red-contrib-viseo-blink": "~0.0",
         "node-red-contrib-viseo-bot-message": "~0.1",
         "node-red-contrib-viseo-credentials": "~0.0",
-        "node-red-contrib-viseo-botbuilder": "~0.5",
+        "node-red-contrib-viseo-botbuilder": "~0.6",
         "node-red-contrib-viseo-chatbase": "~0.0",
         "node-red-contrib-viseo-dialogflow": "~0.0",
         "node-red-contrib-viseo-ethjs": "~0.0",


### PR DESCRIPTION
Update to use version 0.6 of node-red-contrib-viseo-botbuilder (published 23 days ago)